### PR TITLE
feat(host,gameplay,app): enable navigation between host and gameplay screens

### DIFF
--- a/draw.it.client/src/App.jsx
+++ b/draw.it.client/src/App.jsx
@@ -10,7 +10,7 @@ function App() {
             <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/host/:roomId" element={<HostScreen />} />
-                <Route path="/host/:roomId/gameplay" element={<GameplayScreen />}/>
+                <Route path="/gameplay/:roomId" element={<GameplayScreen />}/>
             </Routes>
         </BrowserRouter>
     )

--- a/draw.it.client/src/App.jsx
+++ b/draw.it.client/src/App.jsx
@@ -10,7 +10,7 @@ function App() {
             <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/host/:roomId" element={<HostScreen />} />
-                <Route path="/gameplay" element={<GameplayScreen />}/>
+                <Route path="/host/:roomId/gameplay" element={<GameplayScreen />}/>
             </Routes>
         </BrowserRouter>
     )

--- a/draw.it.client/src/pages/Host/HostScreen.jsx
+++ b/draw.it.client/src/pages/Host/HostScreen.jsx
@@ -67,7 +67,7 @@ function HostScreen() {
 
             if (response.status === 200) {
                 alert(`Kambarys ${roomId} sukurtas..`);
-                navigate(`/host/${roomId}/gameplay`);
+                navigate(`/gameplay/${roomId}`);
             } else {
                 alert('Klaida kuriant kambari.');
                 console.error('Failed to create room with status:', response.status);

--- a/draw.it.client/src/pages/Host/HostScreen.jsx
+++ b/draw.it.client/src/pages/Host/HostScreen.jsx
@@ -4,6 +4,7 @@ import Input from "@/components/input/Input.jsx"
 import './HostScreen.css';
 import api from "@/utils/api.js";
 import { useParams } from 'react-router'; 
+import { useNavigate } from 'react-router';
 
 function HostScreen() {
     const { roomId } = useParams();
@@ -13,6 +14,7 @@ function HostScreen() {
     const [drawingTime, setDrawingTime] = useState(60);
     const [numberOfRounds, setNumberOfRounds] = useState(2);
     const [loading, setLoading] = useState(false);
+    const navigate = useNavigate();
 
     const [joinedPlayers] = useState([
         { id: 1, name: 'Player 1', isReady: true },
@@ -65,6 +67,7 @@ function HostScreen() {
 
             if (response.status === 200) {
                 alert(`Kambarys ${roomId} sukurtas..`);
+                navigate(`/host/${roomId}/gameplay`);
             } else {
                 alert('Klaida kuriant kambari.');
                 console.error('Failed to create room with status:', response.status);


### PR DESCRIPTION
Added navigation from host screen to gameplay screen using the roomId that gets generated when creating a room. This approach will be subject ot change probably, when adding other screen and/or changing the approach with starting the game. This change's for the evaluation of our project on thursday (2025/02/10)