### PR TITLE
Ensure user RoomId is cleared when room is deleted

### DIFF
--- a/Draw.it.Server/Services/Room/RoomService.cs
+++ b/Draw.it.Server/Services/Room/RoomService.cs
@@ -83,7 +83,9 @@ public class RoomService : IRoomService
             throw new AppException("Cannot delete room while the game is in progress.", HttpStatusCode.Forbidden);
         }
 
-        // TODO: Remove roomId from all users that had this roomId set
+        _userService.RemoveRoomFromAllUsers(roomId);
+
+        _roomRepository.DeleteById(roomId);
     }
 
     public RoomModel GetRoom(string roomId)

--- a/Draw.it.Server/Services/User/IUserService.cs
+++ b/Draw.it.Server/Services/User/IUserService.cs
@@ -9,4 +9,5 @@ public interface IUserService
     UserModel GetUser(long userId);
     void SetRoom(long userId, string? roomId);
     void SetReady(long userId, bool isReady);
+    void RemoveRoomFromAllUsers(string roomId);
 }

--- a/Draw.it.Server/Services/User/UserService.cs
+++ b/Draw.it.Server/Services/User/UserService.cs
@@ -60,4 +60,16 @@ public class UserService : IUserService
         _logger.LogInformation("User {} ready status set to {}", userId, isReady);
     }
 
+    public void RemoveRoomFromAllUsers(string roomId)
+    {
+        var users = _userRepository.FindByRoomId(roomId);
+
+        foreach (var user in users)
+        {
+            user.RoomId = null;
+
+            _userRepository.Save(user);
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes issue where users remained associated with a non-existent room after the host deleted it.

- Implements IUserService RemoveRoomFromAllUsers method which sets UserModel RoomId to null for all players in the specified room.
- Calls this new UserService method within RoomService DeleteRoom before the room is removed from the repository.