### PR TITLE
Remove players from deleted room

### DIFF
--- a/Draw.it.Server/Hubs/LobbyHub.cs
+++ b/Draw.it.Server/Hubs/LobbyHub.cs
@@ -62,6 +62,7 @@ public class LobbyHub : Hub
                     // If the user is the host, delete the room
                     _roomService.DeleteRoom(roomId, user);
                     _logger.LogInformation("Disconnected: host with id={UserId}. Room {RoomId} deleted.", user.Id, roomId);
+                    await Clients.Group(roomId).SendAsync("ReceiveRoomDeleted");
                 }
                 else
                 {

--- a/draw.it.client/src/pages/room/RoomPage.jsx
+++ b/draw.it.client/src/pages/room/RoomPage.jsx
@@ -44,8 +44,15 @@ export default function RoomPage() {
             }));
         });
 
+        lobbyConnection.on("ReceiveRoomDeleted", () => {
+            console.warn("Room was deleted by host. Navigating to index.");
+            alert("The room was deleted by the host.");
+            navigate("/");
+        });
+
         return () => {
             lobbyConnection.off("ReceiveUpdateSettings");
+            lobbyConnection.off("ReceiveRoomDeleted");
         }
     }, [lobbyConnection, roomId]);
 


### PR DESCRIPTION
Added to hub ReceiveRoomDeleted, so when front gets this it removes  player from deleted room.