### PR TITLE
Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -46,6 +46,7 @@ flags:
       - draw.it.client/src/main.tsx
 
 ignore:
-  - Draw.it.Server/data/
-  - Draw.it.Server/Integrations/
   - Draw.it.Server/Program.cs
+  - Draw.it.Server/data/
+  - Draw.it.Server/Migrations/
+  - Draw.it.Server/**/*DependencyInjection.cs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,27 @@
 coverage:
   range: 50..80
 
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+
+    patch:
+      backend:
+        target: 80%
+        threshold: 1%
+        flags:
+          - backend-unit
+        only_pulls: true
+
+      frontend:
+        target: auto
+        threshold: 1%
+        flags:
+          - frontend-unit
+        only_pulls: true
+
 flag_management:
   default_rules:
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,49 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+flags:
+  backend-unit:
+    paths:
+      - Draw.it.Server/
+  frontend-unit:
+    paths:
+      - draw.it.client/
+
+coverage:
+  range: 50..80
+  round: down
+  precision: 2
+  
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+        if_ci_failed: error
+      backend:
+        target: 80%
+        threshold: 1%
+        paths:
+          - "Draw.it.Server/**"
+        flags:
+          - backend-unit
+      frontend:
+        target: 80%
+        threshold: 1%
+        paths:
+          - "draw.it.client/**"
+        flags:
+          - frontend-unit
+    
+    patch:
+      default:
+        target: 70%
+        threshold: 1%
+        if_ci_failed: error

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,5 @@
-codecov:
-  require_ci_to_pass: true
-  notify:
-    wait_for_ci: true
+coverage:
+  range: 50..80
 
 flag_management:
   default_rules:
@@ -11,39 +9,22 @@ flags:
   backend-unit:
     paths:
       - Draw.it.Server/
+    ignore:
+      - Draw.it.Server/Repositories/Room/DbRoomRepository.cs
+      - Draw.it.Server/Repositories/User/DbUserRepository.cs
+      - Draw.it.Server/Repositories/WordPool/FileStreamWordPoolRepository.cs
   frontend-unit:
     paths:
-      - draw.it.client/
+      - draw.it.client/src/
+    ignore:
+      - draw.it.client/src/constants/
+      - draw.it.client/src/pages/
+      - draw.it.client/src/utils/api.js
+      - draw.it.client/src/utils/HubFactory.jsx
+      - draw.it.client/src/App.tsx
+      - draw.it.client/src/main.tsx
 
-coverage:
-  range: 50..80
-  round: down
-  precision: 2
-  
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 1%
-        base: auto
-        if_ci_failed: error
-      backend:
-        target: 80%
-        threshold: 1%
-        paths:
-          - "Draw.it.Server/**"
-        flags:
-          - backend-unit
-      frontend:
-        target: 80%
-        threshold: 1%
-        paths:
-          - "draw.it.client/**"
-        flags:
-          - frontend-unit
-    
-    patch:
-      default:
-        target: 70%
-        threshold: 1%
-        if_ci_failed: error
+ignore:
+  - Draw.it.Server/data/
+  - Draw.it.Server/Integrations/
+  - Draw.it.Server/Program.cs


### PR DESCRIPTION
This PR configures Codecov to align with our CI setup and provide consistent feedback about test coverage in pull requests. In practice, this configuration provides:
- Coverage feedback is shown as a message on PRs, so reviewers can see if new code is tested
- Backend and frontend are treated independently
- Only code touched in the PR is checked strictly, which avoids blocking changes because of our old code
- Files that are not meant to be unit-tested (code tested by integration test, migrations, React routing, etc.) are excluded to keep coverage meaningful